### PR TITLE
Display proper vol/no content on archive page

### DIFF
--- a/templates/frontend/objects/issue_summary.tpl
+++ b/templates/frontend/objects/issue_summary.tpl
@@ -1,0 +1,42 @@
+{**
+ * templates/frontend/objects/issue_summary.tpl
+ *
+ * Copyright (c) 2014-2018 Simon Fraser University
+ * Copyright (c) 2003-2018 John Willinsky
+ * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+ *
+ * @brief View of an Issue which displays a summary for use in lists
+ *
+ * @uses $issue Issue The issue
+ *}
+{if $issue->getShowTitle()}
+{assign var=issueTitle value=$issue->getLocalizedTitle()}
+{/if}
+{assign var=issueSeries value=$issue->getIssueSeries()}
+{assign var=issueCover value=$issue->getLocalizedCoverImageUrl()}
+
+<div class="obj_issue_summary">
+
+        {if $issueCover}
+                <a class="cover" href="{url op="view" path=$issue->getBestIssueId()}">
+                        <img src="{$issueCover|escape}"{if $issue->getLocalizedCoverImageAltText() != ''} alt="{$issue->getLocalizedCoverImageAltText()|escape}"{/if}>
+                </a>
+        {/if}
+
+        <a class="title" href="{url op="view" path=$issue->getBestIssueId()}">
+                {if $issueTitle}
+                        {$issueTitle|escape}
+                {else}
+                        {$ctThemePlugin->getIssueIdentification($issue)|strip_unsafe_html}
+                {/if}
+        </a>
+        {if $issueTitle && $issueSeries}
+                <div class="series">
+                        {$issueSeries|escape}
+                </div>
+        {/if}
+
+        <div class="description">
+                {$issue->getLocalizedDescription()|strip_unsafe_html}
+        </div>
+</div><!-- .obj_issue_summary -->


### PR DESCRIPTION
Added an issue_summary_tpl file to the theme so that 

{$ctThemePlugin->getIssueIdentification($issue)|strip_unsafe_html}

... could be properly called for the archives page (eg. journal.com/index.php/journal/issue/archive)